### PR TITLE
fix: Fail job if any call fails

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3015,7 +3015,8 @@ async function request(url, method, payload, headers, vaultCert) {
     const response = await axios(config);
     return response;
   } catch (error) {
-    console.error(error);
+    console.error(error.message);
+    return error.response;
   }
 }
 
@@ -3098,6 +3099,7 @@ async function getVaultToken(vaultUrl, vaultAuthPayload) {
   var statusCode = authResponse.status;
   if (statusCode >= 400) {
     core.setFailed(`Failed to login via the provided approle with status code: ${statusCode}`);
+    process.exit(1);
   }
 
   var data = authResponse.data;
@@ -3115,7 +3117,8 @@ async function getLeaseAndKey(vaultUrl, rolesetPath, vaultToken) {
 
   var statusCode = serviceAccountResponse.status;
   if (statusCode >= 400) {
-    core.setFailed(`Failed to access provided rolset path with status code: ${statusCode}`);
+    core.setFailed(`Failed to access provided roleset path with status code: ${statusCode}`);
+    process.exit(1);
   }
 
   var saData = serviceAccountResponse.data;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcloud-vault-action",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "description": "Authenticate to gcloud via vault, and execute scripts",
   "main": "src/index.js",
   "dependencies": {

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -13,7 +13,8 @@ async function request(url, method, payload, headers, vaultCert) {
     const response = await axios(config);
     return response;
   } catch (error) {
-    console.error(error);
+    console.error(error.message);
+    return error.response;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,7 @@ async function getVaultToken(vaultUrl, vaultAuthPayload) {
   var statusCode = authResponse.status;
   if (statusCode >= 400) {
     core.setFailed(`Failed to login via the provided approle with status code: ${statusCode}`);
+    process.exit(1);
   }
 
   var data = authResponse.data;
@@ -87,7 +88,8 @@ async function getLeaseAndKey(vaultUrl, rolesetPath, vaultToken) {
 
   var statusCode = serviceAccountResponse.status;
   if (statusCode >= 400) {
-    core.setFailed(`Failed to access provided rolset path with status code: ${statusCode}`);
+    core.setFailed(`Failed to access provided roleset path with status code: ${statusCode}`);
+    process.exit(1);
   }
 
   var saData = serviceAccountResponse.data;


### PR DESCRIPTION
Fixed a bug that made the job still succeed even if there was an error making an API call.
Removed stack trace from output